### PR TITLE
Loosen the requirements for EasyAdmin and Symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "symfony-bundle",
     "require": {
         "php": ">=8.0",
-        "symfony/framework-bundle": ">=5.2",
-        "easycorp/easyadmin-bundle": "^4.5"
+        "symfony/framework-bundle": "^5.4|^6.0",
+        "easycorp/easyadmin-bundle": "^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Changed requirements to:
* symfony/framework-bundle ^5.4|^6.0
* asycorp/easyadmin-bundle ^4.0