### PR TITLE
Fix PrettyUrlsGenerator for PHP 8.0

### DIFF
--- a/src/Routing/PrettyUrlsGenerator.php
+++ b/src/Routing/PrettyUrlsGenerator.php
@@ -16,8 +16,8 @@ class PrettyUrlsGenerator implements UrlGeneratorInterface
     public const EA_ACTION = 'crudAction';
 
     public function __construct(
-        private readonly RouterInterface $router,
-        private readonly LoggerInterface $logger,
+        private RouterInterface $router,
+        private LoggerInterface $logger,
     ) {
     }
 


### PR DESCRIPTION
Dropped `readonly` modifier from constructor parameters to allow PHP 8.0 usage